### PR TITLE
a easier way to retrieval without deploying Qdrant locally

### DIFF
--- a/configs/paper/processing-asqa-retrieval.yaml
+++ b/configs/paper/processing-asqa-retrieval.yaml
@@ -20,7 +20,7 @@ steps:
     - _target_:
             ragfit.processing.local_steps.retrievers.haystack.HaystackRetriever
       inputs: [train, dev]
-      pipeline_or_yaml_path: ./configs/external/haystack/qdrant.yaml
+      pipeline_or_yaml_path: null
       docs_key: positive_passages
       query_key: query
 


### PR DESCRIPTION
Dear authors:
    Thank you for your excellent work. While attempting to reproduce the results of this paper, I noticed that the Qdrant retrieval implementation could be made clearer. Additionally, the current implementation requires significant deployment space. To address these issues, I have rewritten haystack.py to provide a simpler solution using Qdrant Cloud. This implementation only requires users to register an account to obtain their URL and API key.