### PR TITLE
feat: add MiniMax as cloud LLM provider for inference and processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ fields and metadata. See [Processing.md](docs/processing.md).
 * **Training**: using PEFT for efficient training and TRL (e.g. supervised FT) users can train any model on the augmented
 datasets. Training is done on the completions. Models can be pushed to HF Hub. See [Training.md](docs/training.md).
 
-* **Inference**: generating predictions using the augmented datasets with trained or untrained LLMs. See [Inference.md](docs/inference.md).
+* **Inference**: generating predictions using the augmented datasets with trained or untrained LLMs. Supports HuggingFace models,
+vLLM, Azure OpenAI, and [MiniMax](https://www.minimaxi.com/) cloud API. See [Inference.md](docs/inference.md).
 
 * **Evaluation**: running evaluation on the generated output from the inference module. Users can provide a list of
 metrics to run; custom metrics can be implemented easily. Current metrics include EM, F1, ROUGE, BERTScore, Deepeval,
@@ -53,6 +54,36 @@ RAGAS, HF `evaluate` and classification. Metrics can be *local*—run on each ex
 dataset, e.g. recall. Metrics can utilize any feature in the dataset, like retrieval results, reasoning,
 citations and attributions, not just the input and output texts. See [Evaluation.md](docs/evaluation.md).
 
+
+## Cloud LLM Providers
+
+RAG-FiT supports cloud LLM APIs for both data processing (augmenting datasets with LLM-generated content) and inference.
+
+### Azure OpenAI
+
+Used via `OpenAIExecutor` / `OpenAIChat`. Requires an Azure endpoint and API key.
+
+### MiniMax
+
+[MiniMax](https://www.minimaxi.com/) provides powerful LLMs (MiniMax-M2.7, MiniMax-M2.7-highspeed) through an OpenAI-compatible API.
+
+**Setup**: Set the `MINIMAX_API_KEY` environment variable.
+
+**Inference** with MiniMax:
+```sh
+MINIMAX_API_KEY=your_key python inference.py -cp configs -cn inference-minimax
+```
+
+**Processing** with MiniMax (data augmentation):
+```yaml
+- _target_: ragfit.processing.local_steps.api.minimax.MiniMaxChat
+  inputs: train
+  prompt_key: prompt
+  answer_key: generated_answer
+  instruction: ragfit/processing/prompts/prompt_instructions/qa.txt
+  model:
+      model: MiniMax-M2.7
+```
 
 ## Running
 The 4 modules are represented as scripts: `processing.py`, `training.py`, `inference.py` and `evaluation.py` at the top

--- a/configs/inference-minimax.yaml
+++ b/configs/inference-minimax.yaml
@@ -1,0 +1,18 @@
+# MiniMax Cloud API inference configuration.
+# Requires MINIMAX_API_KEY environment variable.
+# Supported models: MiniMax-M2.7, MiniMax-M2.7-highspeed
+
+model:
+    _target_: ragfit.models.minimax_executor.MiniMaxExecutor
+    model: MiniMax-M2.7
+    chat_parameters:
+        temperature: 0.7
+        max_tokens: 200
+        top_p: 0.95
+
+data_file: my-processed-data.jsnol
+generated_file: model-predictions.jsonl
+input_key: prompt
+generation_key: output
+target_key: answer
+limit:

--- a/ragfit/models/minimax_executor.py
+++ b/ragfit/models/minimax_executor.py
@@ -1,0 +1,119 @@
+import logging
+import os
+import time
+from typing import List, Union
+
+from openai import OpenAI
+
+
+class MiniMaxExecutor:
+    """
+    Class representing an interface to the MiniMax API.
+
+    MiniMax provides an OpenAI-compatible API at https://api.minimax.io/v1.
+    Supported models include MiniMax-M2.7 and MiniMax-M2.7-highspeed.
+    """
+
+    MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+    def __init__(
+        self,
+        api_key: str = None,
+        base_url: str = None,
+        model: str = "MiniMax-M2.7",
+        chat_parameters: dict = None,
+        delay: int = 1,
+    ):
+        """
+        Initialize the MiniMaxExecutor.
+
+        Args:
+            api_key (str): The API key. Can also be read from MINIMAX_API_KEY env variable.
+            base_url (str): Override the base URL. Defaults to MiniMax's OpenAI-compatible endpoint.
+            model (str): The model to use. Defaults to "MiniMax-M2.7".
+            chat_parameters (dict): The chat parameters.
+            delay (int): Delay between calls in seconds.
+        """
+        self.delay = delay
+        self.model = model
+        self.chat_parameters = dict(
+            temperature=0.7,
+            max_tokens=200,
+            top_p=0.95,
+            frequency_penalty=0,
+            presence_penalty=0,
+            stop=None,
+        )
+        if chat_parameters:
+            self.chat_parameters.update(chat_parameters)
+
+        # Clamp temperature to MiniMax's accepted range (0, 1]
+        temp = self.chat_parameters.get("temperature", 0.7)
+        if temp is not None:
+            self.chat_parameters["temperature"] = max(0.01, min(1.0, temp))
+
+        self.client = OpenAI(
+            api_key=api_key or os.getenv("MINIMAX_API_KEY"),
+            base_url=base_url or self.MINIMAX_BASE_URL,
+        )
+
+    def chat(self, prompt: Union[List, str], instruction: str = None) -> str:
+        """
+        Chat with the MiniMax API.
+
+        Args:
+            prompt (Union[List, str]): The prompt to chat.
+            instruction (str): The instruction to use.
+
+        Returns:
+            str: The response. Empty string if error.
+        """
+        if isinstance(prompt, str):
+            prompt = [
+                {
+                    "role": "system",
+                    "content": (
+                        instruction
+                        or "You are an AI assistant that helps people find information."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ]
+
+        if self.delay:
+            time.sleep(self.delay)
+
+        try:
+            completion = self.client.chat.completions.create(
+                model=self.model,
+                messages=prompt,
+                **self.chat_parameters,
+            )
+            message_obj = completion.choices[0].message
+
+            if hasattr(message_obj, "content"):
+                answer = message_obj.content
+                return answer or ""
+            else:
+                return ""
+
+        except Exception as e:
+            logging.info(f"MiniMax error:\n{e}")
+            return ""
+
+    def generate(self, prompt: str, instruction: str = None) -> str:
+        """
+        Generate text based on the given prompt.
+
+        This method provides a ``generate``-style interface consistent with
+        HFInference and VLLMInference, so ``MiniMaxExecutor`` can be used
+        directly in the inference config (``inference.py``).
+
+        Args:
+            prompt (str): The input prompt.
+            instruction (str): Optional system instruction.
+
+        Returns:
+            str: The generated text.
+        """
+        return self.chat(prompt, instruction)

--- a/ragfit/processing/local_steps/api/minimax.py
+++ b/ragfit/processing/local_steps/api/minimax.py
@@ -1,0 +1,35 @@
+from ragfit.models.minimax_executor import MiniMaxExecutor
+
+from ...step import LocalStep
+
+
+class MiniMaxChat(LocalStep):
+    """
+    Interaction with MiniMax service.
+
+    Model is represented by the ``MiniMaxExecutor``, which uses MiniMax's
+    OpenAI-compatible API (https://api.minimax.io/v1).
+
+    This step is a wrapper, extracting the prompt from the item, interacting
+    with the API, and saving the response to the ``answer`` key in the item.
+    """
+
+    def __init__(self, model, instruction, prompt_key, answer_key, **kwargs):
+        """
+        Args:
+            model (dict): Configuration for the MiniMaxExecutor.
+            instruction (str): Path to the system instruction file.
+            prompt_key (str): Key to the prompt in the item.
+            answer_key (str): Key to store the response.
+        """
+        super().__init__(**kwargs)
+
+        self.model = MiniMaxExecutor(**model)
+        self.prompt_key = prompt_key
+        self.answer_key = answer_key
+        self.instruction = open(instruction).read()
+
+    def process_item(self, item, index, datasets, **kwargs):
+        answer = self.model.chat(item[self.prompt_key], self.instruction)
+        item[self.answer_key] = answer
+        return item

--- a/tests/test_minimax_executor.py
+++ b/tests/test_minimax_executor.py
@@ -1,0 +1,327 @@
+"""Unit tests for MiniMaxExecutor."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class TestMiniMaxExecutorInit:
+    """Test MiniMaxExecutor initialization."""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_default_init(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        os.environ["MINIMAX_API_KEY"] = "test-key"
+        executor = MiniMaxExecutor()
+
+        mock_openai.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert executor.model == "MiniMax-M2.7"
+        assert executor.delay == 1
+        del os.environ["MINIMAX_API_KEY"]
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_custom_model(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key", model="MiniMax-M2.7-highspeed"
+        )
+        assert executor.model == "MiniMax-M2.7-highspeed"
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_custom_base_url(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key", base_url="https://custom.endpoint/v1"
+        )
+        mock_openai.assert_called_once_with(
+            api_key="test-key",
+            base_url="https://custom.endpoint/v1",
+        )
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_custom_chat_parameters(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key",
+            chat_parameters={"temperature": 0.5, "max_tokens": 500},
+        )
+        assert executor.chat_parameters["temperature"] == 0.5
+        assert executor.chat_parameters["max_tokens"] == 500
+        # Default values should be preserved for unset params
+        assert executor.chat_parameters["top_p"] == 0.95
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_temperature_clamping_zero(self, mock_openai):
+        """Temperature=0 should be clamped to 0.01 for MiniMax."""
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key",
+            chat_parameters={"temperature": 0.0},
+        )
+        assert executor.chat_parameters["temperature"] == 0.01
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_temperature_clamping_above_one(self, mock_openai):
+        """Temperature > 1 should be clamped to 1.0 for MiniMax."""
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key",
+            chat_parameters={"temperature": 1.5},
+        )
+        assert executor.chat_parameters["temperature"] == 1.0
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_temperature_valid_range(self, mock_openai):
+        """Temperature within (0, 1] should be unchanged."""
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(
+            api_key="test-key",
+            chat_parameters={"temperature": 0.3},
+        )
+        assert executor.chat_parameters["temperature"] == 0.3
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_env_api_key(self, mock_openai):
+        """API key should fall back to MINIMAX_API_KEY env variable."""
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        os.environ["MINIMAX_API_KEY"] = "env-test-key"
+        executor = MiniMaxExecutor()
+        mock_openai.assert_called_once_with(
+            api_key="env-test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        del os.environ["MINIMAX_API_KEY"]
+
+
+class TestMiniMaxExecutorChat:
+    """Test MiniMaxExecutor chat method."""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_with_string_prompt(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Test response"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.chat("Hello", "Be helpful")
+
+        assert result == "Test response"
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "Be helpful"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"] == "Hello"
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_with_message_list(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Response"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        messages = [
+            {"role": "system", "content": "System msg"},
+            {"role": "user", "content": "User msg"},
+        ]
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.chat(messages)
+
+        assert result == "Response"
+        call_args = mock_client.chat.completions.create.call_args
+        assert call_args.kwargs["messages"] == messages
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_default_instruction(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Response"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        executor.chat("Hello")
+
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        assert "AI assistant" in messages[0]["content"]
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_error_returns_empty(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_client.chat.completions.create.side_effect = Exception("API error")
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.chat("Hello")
+
+        assert result == ""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_empty_content_returns_empty(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = None
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.chat("Hello")
+
+        assert result == ""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_chat_model_parameter(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "OK"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(
+            api_key="test-key", model="MiniMax-M2.7-highspeed", delay=0
+        )
+        executor.chat("Hi")
+
+        call_args = mock_client.chat.completions.create.call_args
+        assert call_args.kwargs["model"] == "MiniMax-M2.7-highspeed"
+
+
+class TestMiniMaxExecutorGenerate:
+    """Test MiniMaxExecutor generate method (inference interface)."""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_generate_delegates_to_chat(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Generated text"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.generate("prompt text")
+
+        assert result == "Generated text"
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_generate_with_instruction(self, mock_openai):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Answer"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        executor = MiniMaxExecutor(api_key="test-key", delay=0)
+        result = executor.generate("prompt text", instruction="Custom instruction")
+
+        assert result == "Answer"
+        call_args = mock_client.chat.completions.create.call_args
+        messages = call_args.kwargs["messages"]
+        assert messages[0]["content"] == "Custom instruction"
+
+
+class TestMiniMaxChatStep:
+    """Test MiniMaxChat processing step."""
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_process_item(self, mock_openai, tmp_path):
+        from ragfit.processing.local_steps.api.minimax import MiniMaxChat
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Generated answer"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        # Create a temporary instruction file
+        instruction_file = tmp_path / "instruction.txt"
+        instruction_file.write_text("You are a helpful assistant.")
+
+        step = MiniMaxChat(
+            model={"api_key": "test-key", "delay": 0},
+            instruction=str(instruction_file),
+            prompt_key="prompt",
+            answer_key="answer",
+        )
+
+        item = {"prompt": "What is RAG?"}
+        result = step.process_item(item, 0, {})
+
+        assert result["answer"] == "Generated answer"
+
+    @patch("ragfit.models.minimax_executor.OpenAI")
+    def test_process_item_preserves_other_keys(self, mock_openai, tmp_path):
+        from ragfit.processing.local_steps.api.minimax import MiniMaxChat
+
+        mock_client = MagicMock()
+        mock_openai.return_value = mock_client
+        mock_choice = MagicMock()
+        mock_choice.message.content = "Answer"
+        mock_client.chat.completions.create.return_value = MagicMock(
+            choices=[mock_choice]
+        )
+
+        instruction_file = tmp_path / "instruction.txt"
+        instruction_file.write_text("Instruction")
+
+        step = MiniMaxChat(
+            model={"api_key": "test-key", "delay": 0},
+            instruction=str(instruction_file),
+            prompt_key="prompt",
+            answer_key="answer",
+        )
+
+        item = {"prompt": "Q?", "context": "Some context", "id": 42}
+        result = step.process_item(item, 0, {})
+
+        assert result["answer"] == "Answer"
+        assert result["context"] == "Some context"
+        assert result["id"] == 42

--- a/tests/test_minimax_integration.py
+++ b/tests/test_minimax_integration.py
@@ -1,0 +1,40 @@
+"""Integration tests for MiniMax executor (require MINIMAX_API_KEY)."""
+
+import os
+
+import pytest
+
+MINIMAX_API_KEY = os.getenv("MINIMAX_API_KEY")
+skip_no_key = pytest.mark.skipif(
+    not MINIMAX_API_KEY,
+    reason="MINIMAX_API_KEY not set",
+)
+
+
+@skip_no_key
+class TestMiniMaxExecutorIntegration:
+    """Integration tests that call the real MiniMax API."""
+
+    def test_chat_basic(self):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(delay=0)
+        result = executor.chat("What is 1 + 1? Reply with just the number.")
+        assert result.strip(), "Expected non-empty response"
+
+    def test_chat_with_instruction(self):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(delay=0)
+        result = executor.chat(
+            "What is RAG?",
+            instruction="Reply in one short sentence.",
+        )
+        assert len(result) > 0
+
+    def test_generate_interface(self):
+        from ragfit.models.minimax_executor import MiniMaxExecutor
+
+        executor = MiniMaxExecutor(delay=0)
+        result = executor.generate("Say hello in French.")
+        assert result.strip(), "Expected non-empty response from generate()"


### PR DESCRIPTION
## Summary

Adds [MiniMax](https://www.minimaxi.com/) as an alternative cloud LLM provider alongside the existing Azure OpenAI integration. MiniMax offers powerful models (MiniMax-M2.7, MiniMax-M2.7-highspeed with 204K context) through an OpenAI-compatible API.

### Changes

- **`ragfit/models/minimax_executor.py`**: `MiniMaxExecutor` class using OpenAI-compatible SDK with MiniMax's base URL, automatic temperature clamping to (0, 1], and a `generate()` method for inference compatibility
- **`ragfit/processing/local_steps/api/minimax.py`**: `MiniMaxChat` processing step (mirrors `OpenAIChat`) for dataset augmentation pipelines
- **`configs/inference-minimax.yaml`**: Ready-to-use inference configuration with MiniMax-M2.7
- **`tests/test_minimax_executor.py`**: 18 unit tests covering initialization, temperature clamping, chat, generate, and processing step
- **`tests/test_minimax_integration.py`**: 3 integration tests (skipped when `MINIMAX_API_KEY` is not set)
- **`README.md`**: Updated with MiniMax provider documentation and usage examples

### Usage

**Inference:**
```sh
MINIMAX_API_KEY=your_key python inference.py -cp configs -cn inference-minimax
```

**Processing pipeline:**
```yaml
- _target_: ragfit.processing.local_steps.api.minimax.MiniMaxChat
  inputs: train
  prompt_key: prompt
  answer_key: generated_answer
  instruction: ragfit/processing/prompts/prompt_instructions/qa.txt
  model:
      model: MiniMax-M2.7
```

## Test Plan

- [x] 18 unit tests pass (mocked API)
- [x] 3 integration tests pass with real MiniMax API
- [x] Import and Hydra instantiation verified
- [ ] Verify existing tests are not affected